### PR TITLE
fixing _sendInfoToPubSub function

### DIFF
--- a/tsante-mqtt.js
+++ b/tsante-mqtt.js
@@ -92,7 +92,6 @@ Polymer({
      */
     client: {
       type: Object,
-      notify: true
     },
 
     /**
@@ -125,7 +124,9 @@ Polymer({
   _sendInfoToPubSub (connected, client) {
     let pubSubs = [].slice.call(this.querySelectorAll('tsante-mqtt-publisher, tsante-mqtt-subscriber'))
     for (let pubSub of pubSubs) {
-      pubSub.setNeededProperties(connected, client)
+      if (typeof pubSub.setNeededProperties === 'function') {
+        pubSub.setNeededProperties(connected, client)
+      }
     }
   },
 


### PR DESCRIPTION
the pubSub.setNeededProperties function is now called only when it is defined (as a function)