### PR TITLE
Feature/topic changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## current
+
+Fix issue #15
+
 ## 1.4.1
 
 Fix issue #13

--- a/test/tsante-mqtt_test.html
+++ b/test/tsante-mqtt_test.html
@@ -234,18 +234,19 @@
         const subscriber = element.querySelector('tsante-mqtt-subscriber')
         const oldValue = subscriber.topic
         const newValue = 'terminal/titi'
+
         subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
           // Subscription
           expect(evt.detail.status).to.equal(true)
           expect(subscriber.subscribed).to.equal(true)
           expect(subscriber.topic).to.equal(oldValue)
-          
+
           subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
             // Unsubscribe from old topic
             expect(evt.detail.status).to.equal(false)
             expect(subscriber.subscribed).to.equal(false)
             expect(subscriber.topic).to.equal(newValue)
-            
+
             subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
               // Subscribe to the new topic
               expect(evt.detail.status).to.equal(true)
@@ -254,8 +255,7 @@
               done()
             }, { once: true })
           }, { once: true })
-          
-          setTimeout(() => subscriber.topic = newValue, 300)
+          setTimeout(() => { subscriber.topic = newValue }, 300)
         }, { once: true })
         element.host = `ws://${mosquittoUrl}:${mosquittoPort}/`
       })

--- a/test/tsante-mqtt_test.html
+++ b/test/tsante-mqtt_test.html
@@ -229,6 +229,37 @@
         )
       })
 
+      it('subscriber should unsubscribe from old topic and subscribe to the new when its topic has changed', (done) => {
+        const element = fixture('basic')
+        const subscriber = element.querySelector('tsante-mqtt-subscriber')
+        const oldValue = subscriber.topic
+        const newValue = 'terminal/titi'
+        subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
+          // Subscription
+          expect(evt.detail.status).to.equal(true)
+          expect(subscriber.subscribed).to.equal(true)
+          expect(subscriber.topic).to.equal(oldValue)
+          
+          subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
+            // Unsubscribe from old topic
+            expect(evt.detail.status).to.equal(false)
+            expect(subscriber.subscribed).to.equal(false)
+            expect(subscriber.topic).to.equal(newValue)
+            
+            subscriber.addEventListener('tsante-mqtt-subscribed', (evt) => {
+              // Subscribe to the new topic
+              expect(evt.detail.status).to.equal(true)
+              expect(subscriber.subscribed).to.equal(true)
+              expect(subscriber.topic).to.equal(newValue)
+              done()
+            }, { once: true })
+          }, { once: true })
+          
+          setTimeout(() => subscriber.topic = newValue, 300)
+        }, { once: true })
+        element.host = `ws://${mosquittoUrl}:${mosquittoPort}/`
+      })
+
       it('only concerned subscribers should receive the published message', async () => {
         const element = fixture('basic')
         await Promise.all([

--- a/tsante-mqtt-subscriber.js
+++ b/tsante-mqtt-subscriber.js
@@ -121,8 +121,8 @@ Polymer({
   _topicChanged: function (newValue, oldValue) {
     if (newValue !== oldValue) {
       if (oldValue && this.subscribed) {
+        this.addEventListener('tsante-mqtt-subscribed', this.subscribe, {once: true})
         this.unsubscribe(oldValue)
-        this.addEventListener('tsante-mqtt-subscribed', this.subscribe)
       } else {
         this.subscribe()
       }
@@ -138,9 +138,10 @@ Polymer({
    * @param {*} client the mqtt client of the tsante-mqtt parent
    */
   subscribe: function (connected, client) {
-    if (connected && !this.subscribed) {
-      this.removeEventListener('tsante-mqtt-subscribed', this.subscribe)
-      client.subscribe(this.topic, {
+    this._client = this._client || client
+    this._connected = this._connected || connected
+    if (this._connected && !this.subscribed) {
+      this._client.subscribe(this.topic, {
         onSuccess: this._onSubscribe.bind(this),
         onFailure: this._onSubscribeFail.bind(this),
         invocationContext: { topic: this.topic },


### PR DESCRIPTION
Fix topicChanged listener

When the topic is changed, the subscriber unsubscribes from the old topic, but does not subscribe to the new one.

This amazing branch fixes that, and even adds some unit testings to check that !